### PR TITLE
Some small changes to make it at least make it to the linker step of building on my mac.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 MAKEFLAGS+="-j 4"
 flags=-g --std=c++14 -Wall
 
+ifeq ($(lua),)
+lua=5.2
+endif
+
 ifeq ($(prof),)
-libs=-llua5.2
-includes=-I/usr/local/include/lua5.2/
+libs=$(shell pkg-config lua$(lua) --libs)
+includes=$(shell pkg-config lua$(lua) --cflags)
 else
 $(info profile build)
 libs=-L../gperftools-2.5/.libs/ -ldl -lprofiler ../lua-5.3.4/src/liblua.a
@@ -12,10 +16,6 @@ bin=-profiled
 flags+=-Wl,--no-as-needed
 endif
 
-ifeq ($(lua),5.3)
-libs=-llua5.3
-includes=-I/usr/local/include/lua5.3/
-endif
 
 includes+=-I.
 libs+=-lstdc++ -lstdc++fs -pthread

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ flags=-g --std=c++14 -Wall
 
 ifeq ($(prof),)
 libs=-llua5.2
-includes=-I/usr/include/lua5.2/
+includes=-I/usr/local/include/lua5.2/
 else
 $(info profile build)
 libs=-L../gperftools-2.5/.libs/ -ldl -lprofiler ../lua-5.3.4/src/liblua.a
@@ -14,7 +14,7 @@ endif
 
 ifeq ($(lua),5.3)
 libs=-llua5.3
-includes=-I/usr/include/lua5.3/
+includes=-I/usr/local/include/lua5.3/
 endif
 
 includes+=-I.
@@ -30,13 +30,13 @@ objs = $(files:%.cpp=bin/%$(bin).o)
 deps = $(objs:%.o=%.d)
 
 ocvm$(bin): $(objs) system
-	g++ $(flags) $(objs) $(libs) -o ocvm$(bin)
+	$(CXX) $(flags) $(objs) $(libs) -o ocvm$(bin)
 	@echo done
 
 -include $(deps)
 bin/%$(bin).o : %.cpp
 	@mkdir -p $@D
-	g++ $(flags) $(includes) -MMD -c $< -o $@
+	$(CXX) $(flags) $(includes) -MMD -c $< -o $@
 
 system:
 	@echo downloading OpenComputers system files

--- a/apis/unicode.cpp
+++ b/apis/unicode.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <fstream>
 #include <limits>
+#include <clocale>
 using namespace std;
 
 static const uint32_t end_1_byte = 0x00000080;

--- a/color/color_map.cpp
+++ b/color/color_map.cpp
@@ -2,6 +2,7 @@
 #include <tuple>
 #include <limits>
 #include <cstring>
+#include <algorithm>
 using namespace std;
 
 static int monochrome_color = 0xffffff;

--- a/utils.cpp
+++ b/utils.cpp
@@ -5,6 +5,10 @@
 #include <fstream>
 using namespace std;
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
 #include <unistd.h>
 
 #include <sys/stat.h>
@@ -193,12 +197,22 @@ string utils::proc_root()
     {
         constexpr ssize_t size = 1024;
         char buf[size];
+
+#ifdef __APPLE__
+        uint32_t len = size;
+        if(_NSGetExecutablePath(buf, &len) != 0) {
+            cerr << "proc path too long\n";
+            ::exit(1);
+        }
+#else
         ssize_t len = ::readlink("/proc/self/exe", buf, size);
         if (len >= size) // yikes, abort
         {
             cerr << "proc path too long\n";
             ::exit(1);
         }
+#endif
+
         buf[len] = 0;
         path = buf;
 

--- a/value.h
+++ b/value.h
@@ -120,6 +120,12 @@ private:
         return 1;
     }
 
+    inline static int push_ret(lua_State* lua, uint64_t arg)
+    {
+        lua_pushnumber(lua, arg);
+        return 1;
+    }
+
     inline static int push_ret(lua_State* lua, const string& arg)
     {
         lua_pushstring(lua, arg.c_str());


### PR DESCRIPTION
On my mac with the changes in this PR, just doing `make CC=gcc-6 CXX=g++-6` gets as far as trying  to link it, where it chokes, unable to find liblua5.2 for some reason I've not determined yet.

*EDIT* As of 63a511e it now builds completely successfully under gcc-6 on my macbook.