### PR TITLE
Add an unlink call to FileLock::~FileLock

### DIFF
--- a/drivers/modem_drv.h
+++ b/drivers/modem_drv.h
@@ -18,7 +18,8 @@ public:
     static unique_ptr<FileLock> create(const string& path);
     ~FileLock();
 private:
-    FileLock(int fd);
+    FileLock(const string& path, int fd);
+    string _path;
     int _fd;
 };
 


### PR DESCRIPTION
This fixes an issue I'm having where the modem lock doesn't seem to get cleaned up on process exit.