### PR TITLE
Mask unicode glyohs that OC doesn't support by converting them to U+25A1

### DIFF
--- a/apis/unicode.cpp
+++ b/apis/unicode.cpp
@@ -200,7 +200,7 @@ vector<char> UnicodeApi::tochar(const uint32_t codepoint32)
     uint32_t codepoint = codepoint32 & 0xFFFF;
 
     if (font_width.find(codepoint) == font_width.end()) {
-        codepoint = 0x25A1;
+        codepoint = 0xFFFD;
     }
 
     if (codepoint < end_1_byte)

--- a/apis/unicode.cpp
+++ b/apis/unicode.cpp
@@ -199,6 +199,10 @@ vector<char> UnicodeApi::tochar(const uint32_t codepoint32)
     // even though utf8 would support this, i'll truncate here
     uint32_t codepoint = codepoint32 & 0xFFFF;
 
+    if (font_width.find(codepoint) == font_width.end()) {
+        codepoint = 0x25A1;
+    }
+
     if (codepoint < end_1_byte)
     {
         buffer.push_back(codepoint);


### PR DESCRIPTION
I didn't look too-too hard, but I believe that the replacement glyph is
vaid for use as a "missing glyph" glyph.

My thought behind this is to make it more obvious when a glyph that OC can't render is used, and since it turned out to be somewhat simple (At least, for just `unicode.char`) I decided to Just Do It™