### PR TITLE
Add mode in call to open

### DIFF
--- a/drivers/modem_drv.cpp
+++ b/drivers/modem_drv.cpp
@@ -56,7 +56,7 @@ bool ModemDriver::readNextModemMessage(ModemEvent& mev)
 unique_ptr<FileLock> FileLock::create(const string& path)
 {
     // we can only attempt to create the server if we only the file lock
-    int server_pool_file = ::open(path.c_str(), O_CREAT | O_TRUNC);
+    int server_pool_file = ::open(path.c_str(), O_CREAT | O_TRUNC, 0600);
     if (::flock(server_pool_file, LOCK_EX | LOCK_NB) == -1)
     {
         // flock denied


### PR DESCRIPTION
From the open(2) man page on linux:
"[mode_t mode] must be supplied when O_CREAT or O_TMPFILE is specified
in flags"

Without this, compilation with new glibc fails.

For reference, here's the error (glibc 2.26):

```
In file included from (GLIBC)/include/fcntl.h:313:0,
                 from (GLIBC)/include/sys/file.h:24,
                 from drivers/modem_drv.cpp:5:
In function ‘int open(const char*, int, ...)’,
    inlined from ‘static std::unique_ptr<FileLock> FileLock::create(const string&)’ at drivers/modem_drv.cpp:59:66:
/nix/store/(GLIBC)/include/bits/fcntl2.h:50:26: error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
    __open_missing_mode ();
                          ^
```