### PR TITLE
Fix std::string mashaling to/from lua with \0

### DIFF
--- a/model/value.cpp
+++ b/model/value.cpp
@@ -37,7 +37,10 @@ string Value::checkArg<string>(lua_State* lua, int index, const string* pDefault
     if (!has_type)
         return *pDefault;
 
-    return string(lua_tostring(lua, index));
+    size_t len;
+    const char* str = lua_tolstring(lua, index, &len);
+
+    return string(str, len);
 }
 
 template <>

--- a/model/value.h
+++ b/model/value.h
@@ -142,7 +142,7 @@ private:
 
     inline static int push_ret(lua_State* lua, const string& arg)
     {
-        lua_pushstring(lua, arg.c_str());
+        lua_pushlstring(lua, arg.c_str(), arg.length());
         return 1;
     }
 


### PR DESCRIPTION
This fixes string marshaling (#12) for my uses in the data card, but I'm sure there are more instances of this heisenbug hiding around somewhere.