### PR TITLE
sandbox component: Add log method

### DIFF
--- a/components/gpu.cpp
+++ b/components/gpu.cpp
@@ -55,7 +55,8 @@ int Gpu::bind(lua_State* lua)
 {
     string address = Value::checkArg<string>(lua, 1);
     if (_screen && _screen->address() == address)
-        return 0; // already set
+        return ValuePack::ret(lua, true); // already set
+    
 
     Component* pc = client()->component(address);
     if (!pc)
@@ -78,7 +79,7 @@ int Gpu::bind(lua_State* lua)
     tuple<int, int> max = _screen->frame()->size();
     setResolution(std::get<0>(max), std::get<1>(max));
 
-    return 0;
+    return ValuePack::ret(lua, true); 
 }
 
 int Gpu::maxDepth(lua_State* lua)

--- a/components/sandbox.cpp
+++ b/components/sandbox.cpp
@@ -7,6 +7,14 @@ Sandbox::Sandbox()
 {
     add("add_component", &Sandbox::add_component);
     add("remove_component", &Sandbox::remove_component);
+    add("log", &Sandbox::log);
+}
+
+int Sandbox::log(lua_State* lua) {
+    auto msg = Value::checkArg<string>(lua, 1);
+
+    lout() << "lua: " << msg << endl;
+    return 0;
 }
 
 int Sandbox::add_component(lua_State* lua)

--- a/components/sandbox.h
+++ b/components/sandbox.h
@@ -10,6 +10,7 @@ public:
 
     int add_component(lua_State* lua);
     int remove_component(lua_State* lua);
+    int log(lua_State* lua);
 protected:
     bool onInitialize() override;
     


### PR DESCRIPTION
Also, this fixes a possible non-compliant part of gpu.bind, as it was returning nothing, which the machine.lua was interpreting as an error, and causing some code to crash.