### PR TITLE
Append a "/" to the end of list() results if the item in question is a directory.

### DIFF
--- a/components/filesystem.cpp
+++ b/components/filesystem.cpp
@@ -473,6 +473,10 @@ int Filesystem::list(lua_State* lua)
     for (const auto& item : listing)
     {
         string relative_item = clean(relative(request_path, item), false, true);
+        if (fs_utils::isDirectory(item)) {
+            relative_item += "/";
+        }
+
         t.insert(relative_item);
     }
 


### PR DESCRIPTION
This makes it match OC and OCEmu's handling of filesystem.list()