### PR TITLE
component/filesystem: Return infinity instead of max from spaceTotal

### DIFF
--- a/components/filesystem.cpp
+++ b/components/filesystem.cpp
@@ -583,7 +583,7 @@ int Filesystem::spaceUsed(lua_State* lua)
 
 int Filesystem::spaceTotal(lua_State* lua)
 {
-    return ValuePack::ret(lua, numeric_limits<double>::max());
+    return ValuePack::ret(lua, numeric_limits<double>::infinity());
 }
 
 int Filesystem::remove(lua_State* lua)


### PR DESCRIPTION
This displays more resonably in visual displays, at least under both KittenOS NEO and OpenOS.