### PR TITLE
component/internet: Let Linux find wget using PATH instead of hard-coding it to /usr/bin/wget

### DIFF
--- a/drivers/internet_http.cpp
+++ b/drivers/internet_http.cpp
@@ -120,7 +120,7 @@ bool PipedCommand::open(const string& command, const vector<string>& args)
     }
     vargs[args.size() + 1] = nullptr;
 
-    ::execv(command.data(), const_cast<char*const*>(vargs));
+    ::execvp(command.data(), const_cast<char*const*>(vargs));
     delete [] vargs;
     ::_exit(EXIT_FAILURE);
     return false;
@@ -178,7 +178,7 @@ HttpObject::HttpObject(const HttpAddress& addr, const string& post, const map<st
     {
         args.push_back(addr.raw);
         // http request: addr.raw
-        _cmd.open("/usr/bin/wget", args);
+        _cmd.open("wget", args);
     }
 }
 


### PR DESCRIPTION
Just  another step in my line of stuff to change so that it works in NixOS better.

This makes it so that the internet component doesn't use a hard-coded path to wget, by switching from `execv` to `execvp` which will search the PATH environment variable. This allows wget to be in any place, not just the usual one, including allowing users to override it to MITM stuff / mock it locally if they so wish.