### PR TITLE
eeprom/data: Return the correct data type for CRC32

### DIFF
--- a/components/data_card.cpp
+++ b/components/data_card.cpp
@@ -30,8 +30,16 @@ bool DataCard::onInitialize()
 int DataCard::crc32(lua_State* lua)
 {
   vector<char> value = Value::checkArg<vector<char>>(lua, 1);
-
-  return ValuePack::ret(lua, util::crc32(value));
+  uint32_t crc = util::crc32(value);
+  
+  vector<char> ret{
+		   (char)((crc >> 24) & 0xFF),
+		   (char)((crc >> 16) & 0xFF),
+		   (char)((crc >> 8) & 0xFF),
+		   (char)(crc & 0xFF),
+  };
+  
+  return ValuePack::ret(lua, ret);
 }
 
 int DataCard::md5(lua_State* lua)

--- a/components/eeprom.cpp
+++ b/components/eeprom.cpp
@@ -52,8 +52,10 @@ int Eeprom::getChecksum(lua_State* lua)
 {
   vector<char> bios = this->load(biosPath());
   uint32_t crc = util::crc32(bios);
+  std::stringstream ret;
+  ret << std::hex << crc;
 
-  return ValuePack::ret(lua, crc);
+  return ValuePack::ret(lua, ret.str());
 }
 
 int Eeprom::set(lua_State* lua)


### PR DESCRIPTION
Turns out, neither of them return numbers. And eeprom.getChecksum()
returns a hex-formatted string, while data.crc32 returns a
binary-formatted string. Oops.