### PR TITLE
Added FreeBSD build support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ ifeq ($(lua),)
 	lua=5.2
 endif
 
+WGET_PATH = $(shell which wget)
+WGET_OPTS = -O
+
 TARGET_EXEC ?= ocvm
 
 INC_DIRS ?= ./
@@ -40,7 +43,13 @@ ifeq ($(shell uname -s 2>/dev/null),Haiku)
 	SRCS+=$(wildcard $(SRC_DIRS)haiku/*.cpp)
 endif
 
-ifeq (, $(shell which wget))
+ifeq ($(shell uname -s 2>/dev/null), FreeBSD)
+	WGET_PATH = $(shell which fetch)
+	WGET_OPTS = -o 
+	CXX = g++
+endif
+
+ifeq (, $(WGET_PATH))
 	SRCS := $(filter-out $(SRC_DIRS)drivers/internet_http.cpp,$(SRCS))
 endif
 
@@ -64,10 +73,10 @@ system/.keep:
 	@echo Downloading OpenComputers system files
 	mkdir -p system
 	touch system/.keep
-	command -v svn && svn checkout https://github.com/MightyPirates/OpenComputers/trunk/src/main/resources/assets/opencomputers/loot system/loot || echo "\n\e[36;1mwarning: svn not found. The build will continue, you can manually prepare \`.system/\`\e[m\n"
-	wget https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/machine.lua -O system/machine.lua
-	wget https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/bios.lua -O system/bios.lua
-	wget https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/font.hex -O system/font.hex
+	@command -v svn && svn checkout https://github.com/MightyPirates/OpenComputers/trunk/src/main/resources/assets/opencomputers/loot system/loot || echo "\n\e[36;1mwarning: svn not found. The build will continue, you can manually prepare \`.system/\`\e[m\n"
+	$(WGET_PATH) https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/machine.lua $(WGET_OPTS) system/machine.lua
+	$(WGET_PATH) https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/bios.lua $(WGET_OPTS) system/bios.lua
+	$(WGET_PATH) https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/font.hex $(WGET_OPTS) system/font.hex
 
 .PHONY: clean
 

--- a/drivers/raw_tty.cpp
+++ b/drivers/raw_tty.cpp
@@ -25,6 +25,10 @@
 #define KDSKBMODE 0x4B45 /* sets current keyboard mode */
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/kbio.h> /* KDGKBMODE and KDSKBMODE */
+#endif
+
 #include <signal.h>
 #include <string.h> // memset
 #include <time.h>


### PR DESCRIPTION
Additionally adjusted Makefile for use with fetch instead of just wget.
As of this commit all other systems other than FreeBSD should default to wget
and its necessary options.
Suppressed echo of svn command so that the warning message does not mislead anyone.

Please test a recompile on Linux to ensure building continues as normal on that system.

FreeBSD compile output:

g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c main.cpp -o bin/./main.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c apis/native-lua.cpp -o bin/./apis/native-lua.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c apis/os.cpp -o bin/./apis/os.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c apis/system.cpp -o bin/./apis/system.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c apis/unicode.cpp -o bin/./apis/unicode.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c apis/userdata.cpp -o bin/./apis/userdata.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c color/color_map.cpp -o bin/./color/color_map.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/component.cpp -o bin/./components/component.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/computer.cpp -o bin/./components/computer.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/data_card.cpp -o bin/./components/data_card.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/drive.cpp -o bin/./components/drive.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/eeprom.cpp -o bin/./components/eeprom.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/filesystem.cpp -o bin/./components/filesystem.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/gpu.cpp -o bin/./components/gpu.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/internet.cpp -o bin/./components/internet.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/keyboard.cpp -o bin/./components/keyboard.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/modem.cpp -o bin/./components/modem.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/sandbox.cpp -o bin/./components/sandbox.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c components/screen.cpp -o bin/./components/screen.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/ansi.cpp -o bin/./drivers/ansi.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/ansi_escape.cpp -o bin/./drivers/ansi_escape.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/basic_term.cpp -o bin/./drivers/basic_term.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/connection.cpp -o bin/./drivers/connection.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/factory_shell.cpp -o bin/./drivers/factory_shell.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/fs_utils.cpp -o bin/./drivers/fs_utils.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/internet_drv.cpp -o bin/./drivers/internet_drv.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/internet_http.cpp -o bin/./drivers/internet_http.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/kb_data.cpp -o bin/./drivers/kb_data.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/kb_drv.cpp -o bin/./drivers/kb_drv.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/modem_drv.cpp -o bin/./drivers/modem_drv.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/mouse_drv.cpp -o bin/./drivers/mouse_drv.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/raw_tty.cpp -o bin/./drivers/raw_tty.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/server_pool.cpp -o bin/./drivers/server_pool.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/term_buffer.cpp -o bin/./drivers/term_buffer.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c drivers/worker.cpp -o bin/./drivers/worker.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c io/frame.cpp -o bin/./io/frame.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c model/client.cpp -o bin/./model/client.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c model/config.cpp -o bin/./model/config.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c model/host.cpp -o bin/./model/host.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c model/log.cpp -o bin/./model/log.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c model/luaproxy.cpp -o bin/./model/luaproxy.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c model/prof_log.cpp -o bin/./model/prof_log.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c model/value.cpp -o bin/./model/value.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c util/crc32.cpp -o bin/./util/crc32.cpp.o
g++ -I./ -I/usr/include/lua5.2 -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed  -c util/md5.cpp -o bin/./util/md5.cpp.o
Downloading OpenComputers system files
mkdir -p system
touch system/.keep
/usr/local/bin/svn
A    system/loot/README.md
A    system/loot/builder
A    system/loot/builder/usr
A    system/loot/builder/usr/bin
A    system/loot/builder/usr/bin/build.lua
A    system/loot/builder/usr/man
A    system/loot/builder/usr/man/build.man
A    system/loot/builder/usr/share
A    system/loot/builder/usr/share/build-plans
A    system/loot/builder/usr/share/build-plans/example.plan
A    system/loot/data
A    system/loot/data/usr
A    system/loot/data/usr/bin
A    system/loot/data/usr/bin/base64.lua
A    system/loot/data/usr/bin/deflate.lua
A    system/loot/data/usr/bin/gpg.lua
A    system/loot/data/usr/bin/inflate.lua
A    system/loot/data/usr/bin/md5sum.lua
A    system/loot/data/usr/bin/sha256sum.lua
A    system/loot/data/usr/lib
A    system/loot/data/usr/lib/data.lua
A    system/loot/dig
A    system/loot/dig/usr
A    system/loot/dig/usr/bin
A    system/loot/dig/usr/bin/dig.lua
A    system/loot/dig/usr/man
A    system/loot/dig/usr/man/dig.man
A    system/loot/generator
A    system/loot/generator/usr
A    system/loot/generator/usr/bin
A    system/loot/generator/usr/bin/refuel.lua
A    system/loot/irc
A    system/loot/irc/usr
A    system/loot/irc/usr/bin
A    system/loot/irc/usr/bin/irc.lua
A    system/loot/loot.properties
A    system/loot/maze
A    system/loot/maze/usr
A    system/loot/maze/usr/bin
A    system/loot/maze/usr/bin/maze.lua
A    system/loot/maze/usr/man
A    system/loot/maze/usr/man/maze.man
A    system/loot/network
A    system/loot/network/.prop
A    system/loot/network/autorun.lua
A    system/loot/network/data
A    system/loot/network/data/bin
A    system/loot/network/data/bin/arp.lua
A    system/loot/network/data/bin/ifconfig.lua
A    system/loot/network/data/bin/ping.lua
A    system/loot/network/data/bin/route.lua
A    system/loot/network/data/boot
A    system/loot/network/data/boot/80_network.lua
A    system/loot/network/data/boot/95_hostname.lua
A    system/loot/network/data/lib
A    system/loot/network/data/lib/network.lua
A    system/loot/network/data/lib/network
A    system/loot/network/data/lib/network/loopback.lua
A    system/loot/network/data/lib/network/modem.lua
A    system/loot/network/data/lib/network/tunnel.lua
A    system/loot/network/data/usr
A    system/loot/network/data/usr/bin
A    system/loot/network/data/usr/bin/nc.lua
A    system/loot/network/data/usr/man
A    system/loot/network/data/usr/man/ifconfig
A    system/loot/network/data/usr/man/network
A    system/loot/network/data/usr/man/ping
A    system/loot/network/protocol
A    system/loot/openloader
A    system/loot/openloader/.install
A    system/loot/openloader/OpenLoader.man
A    system/loot/openloader/autorun.lua
A    system/loot/openloader/bin
A    system/loot/openloader/bin/opl-flash.lua
A    system/loot/openloader/init.lua
A    system/loot/openos
A    system/loot/openos/.prop
A    system/loot/openos/bin
A    system/loot/openos/bin/address.lua
A    system/loot/openos/bin/alias.lua
A    system/loot/openos/bin/cat.lua
A    system/loot/openos/bin/cd.lua
A    system/loot/openos/bin/clear.lua
A    system/loot/openos/bin/components.lua
A    system/loot/openos/bin/cp.lua
A    system/loot/openos/bin/date.lua
A    system/loot/openos/bin/df.lua
A    system/loot/openos/bin/dmesg.lua
A    system/loot/openos/bin/du.lua
A    system/loot/openos/bin/echo.lua
A    system/loot/openos/bin/edit.lua
A    system/loot/openos/bin/find.lua
A    system/loot/openos/bin/flash.lua
A    system/loot/openos/bin/free.lua
A    system/loot/openos/bin/grep.lua
A    system/loot/openos/bin/head.lua
A    system/loot/openos/bin/hostname.lua
A    system/loot/openos/bin/install.lua
A    system/loot/openos/bin/label.lua
A    system/loot/openos/bin/less.lua
A    system/loot/openos/bin/list.lua
A    system/loot/openos/bin/ln.lua
A    system/loot/openos/bin/ls.lua
A    system/loot/openos/bin/lshw.lua
A    system/loot/openos/bin/lua.lua
A    system/loot/openos/bin/man.lua
A    system/loot/openos/bin/mkdir.lua
A    system/loot/openos/bin/mktmp.lua
A    system/loot/openos/bin/mount.lua
A    system/loot/openos/bin/mv.lua
A    system/loot/openos/bin/pastebin.lua
A    system/loot/openos/bin/primary.lua
A    system/loot/openos/bin/ps.lua
A    system/loot/openos/bin/pwd.lua
A    system/loot/openos/bin/rc.lua
A    system/loot/openos/bin/reboot.lua
A    system/loot/openos/bin/redstone.lua
A    system/loot/openos/bin/resolution.lua
A    system/loot/openos/bin/rm.lua
A    system/loot/openos/bin/rmdir.lua
A    system/loot/openos/bin/set.lua
A    system/loot/openos/bin/sh.lua
A    system/loot/openos/bin/shutdown.lua
A    system/loot/openos/bin/sleep.lua
A    system/loot/openos/bin/source.lua
A    system/loot/openos/bin/time.lua
A    system/loot/openos/bin/touch.lua
A    system/loot/openos/bin/tree.lua
A    system/loot/openos/bin/umount.lua
A    system/loot/openos/bin/unalias.lua
A    system/loot/openos/bin/unset.lua
A    system/loot/openos/bin/uptime.lua
A    system/loot/openos/bin/useradd.lua
A    system/loot/openos/bin/userdel.lua
A    system/loot/openos/bin/wget.lua
A    system/loot/openos/bin/which.lua
A    system/loot/openos/bin/yes.lua
A    system/loot/openos/boot
A    system/loot/openos/boot/00_base.lua
A    system/loot/openos/boot/01_process.lua
A    system/loot/openos/boot/02_os.lua
A    system/loot/openos/boot/03_io.lua
A    system/loot/openos/boot/04_component.lua
A    system/loot/openos/boot/10_devfs.lua
A    system/loot/openos/boot/89_rc.lua
A    system/loot/openos/boot/90_filesystem.lua
A    system/loot/openos/boot/91_gpu.lua
A    system/loot/openos/boot/92_keyboard.lua
A    system/loot/openos/boot/93_term.lua
A    system/loot/openos/boot/94_shell.lua
A    system/loot/openos/etc
A    system/loot/openos/etc/motd
A    system/loot/openos/etc/profile.lua
A    system/loot/openos/etc/rc.cfg
A    system/loot/openos/etc/rc.d
A    system/loot/openos/etc/rc.d/example.lua
A    system/loot/openos/home
A    system/loot/openos/home/.shrc
A    system/loot/openos/init.lua
A    system/loot/openos/lib
A    system/loot/openos/lib/bit32.lua
A    system/loot/openos/lib/buffer.lua
A    system/loot/openos/lib/colors.lua
A    system/loot/openos/lib/core
A    system/loot/openos/lib/core/boot.lua
A    system/loot/openos/lib/core/cursor.lua
A    system/loot/openos/lib/core/devfs
A    system/loot/openos/lib/core/devfs/01_hw.lua
A    system/loot/openos/lib/core/devfs/02_utils.lua
A    system/loot/openos/lib/core/devfs/adapters
A    system/loot/openos/lib/core/devfs/adapters/computer.lua
A    system/loot/openos/lib/core/devfs/adapters/eeprom.lua
A    system/loot/openos/lib/core/devfs/adapters/filesystem.lua
A    system/loot/openos/lib/core/devfs/adapters/gpu.lua
A    system/loot/openos/lib/core/devfs/adapters/internet.lua
A    system/loot/openos/lib/core/devfs/adapters/modem.lua
A    system/loot/openos/lib/core/devfs/adapters/screen.lua
A    system/loot/openos/lib/core/device_labeling.lua
A    system/loot/openos/lib/core/full_buffer.lua
A    system/loot/openos/lib/core/full_cursor.lua
A    system/loot/openos/lib/core/full_event.lua
A    system/loot/openos/lib/core/full_filesystem.lua
A    system/loot/openos/lib/core/full_keyboard.lua
A    system/loot/openos/lib/core/full_ls.lua
A    system/loot/openos/lib/core/full_sh.lua
A    system/loot/openos/lib/core/full_shell.lua
A    system/loot/openos/lib/core/full_text.lua
A    system/loot/openos/lib/core/full_transforms.lua
A    system/loot/openos/lib/core/full_vt.lua
A    system/loot/openos/lib/core/install_basics.lua
A    system/loot/openos/lib/core/install_utils.lua
A    system/loot/openos/lib/core/lua_shell.lua
A    system/loot/openos/lib/devfs.lua
A    system/loot/openos/lib/event.lua
A    system/loot/openos/lib/filesystem.lua
A    system/loot/openos/lib/internet.lua
A    system/loot/openos/lib/io.lua
A    system/loot/openos/lib/keyboard.lua
A    system/loot/openos/lib/note.lua
A    system/loot/openos/lib/package.lua
A    system/loot/openos/lib/pipe.lua
A    system/loot/openos/lib/process.lua
A    system/loot/openos/lib/rc.lua
A    system/loot/openos/lib/serialization.lua
A    system/loot/openos/lib/sh.lua
A    system/loot/openos/lib/shell.lua
A    system/loot/openos/lib/sides.lua
A    system/loot/openos/lib/term.lua
A    system/loot/openos/lib/text.lua
A    system/loot/openos/lib/thread.lua
A    system/loot/openos/lib/tools
A    system/loot/openos/lib/tools/programLocations.lua
A    system/loot/openos/lib/tools/transfer.lua
A    system/loot/openos/lib/transforms.lua
A    system/loot/openos/lib/tty.lua
A    system/loot/openos/lib/uuid.lua
A    system/loot/openos/lib/vt100.lua
A    system/loot/openos/usr
A    system/loot/openos/usr/man
A    system/loot/openos/usr/man/address
A    system/loot/openos/usr/man/alias
A    system/loot/openos/usr/man/cat
A    system/loot/openos/usr/man/cd
A    system/loot/openos/usr/man/clear
A    system/loot/openos/usr/man/cp
A    system/loot/openos/usr/man/date
A    system/loot/openos/usr/man/df
A    system/loot/openos/usr/man/dmesg
A    system/loot/openos/usr/man/echo
A    system/loot/openos/usr/man/edit
A    system/loot/openos/usr/man/grep
A    system/loot/openos/usr/man/head
A    system/loot/openos/usr/man/hostname
A    system/loot/openos/usr/man/install
A    system/loot/openos/usr/man/label
A    system/loot/openos/usr/man/less
A    system/loot/openos/usr/man/ln
A    system/loot/openos/usr/man/ls
A    system/loot/openos/usr/man/lshw
A    system/loot/openos/usr/man/lua
A    system/loot/openos/usr/man/man
A    system/loot/openos/usr/man/mkdir
A    system/loot/openos/usr/man/more
A    system/loot/openos/usr/man/mount
A    system/loot/openos/usr/man/mv
A    system/loot/openos/usr/man/pastebin
A    system/loot/openos/usr/man/primary
A    system/loot/openos/usr/man/pwd
A    system/loot/openos/usr/man/rc
A    system/loot/openos/usr/man/reboot
A    system/loot/openos/usr/man/redstone
A    system/loot/openos/usr/man/resolution
A    system/loot/openos/usr/man/rm
A    system/loot/openos/usr/man/rmdir
A    system/loot/openos/usr/man/set
A    system/loot/openos/usr/man/sh
A    system/loot/openos/usr/man/shutdown
A    system/loot/openos/usr/man/umount
A    system/loot/openos/usr/man/unalias
A    system/loot/openos/usr/man/unset
A    system/loot/openos/usr/man/uptime
A    system/loot/openos/usr/man/useradd
A    system/loot/openos/usr/man/userdel
A    system/loot/openos/usr/man/wget
A    system/loot/openos/usr/man/which
A    system/loot/openos/usr/man/yes
A    system/loot/openos/usr/misc
A    system/loot/openos/usr/misc/greetings.txt
A    system/loot/oppm
A    system/loot/oppm/.install
A    system/loot/oppm/.prop
A    system/loot/oppm/etc
A    system/loot/oppm/etc/oppm.cfg
A    system/loot/oppm/usr
A    system/loot/oppm/usr/bin
A    system/loot/oppm/usr/bin/oppm.lua
A    system/loot/plan9k
A    system/loot/plan9k/.prop
A    system/loot/plan9k/bin
A    system/loot/plan9k/bin/cat.lua
A    system/loot/plan9k/bin/clear.lua
A    system/loot/plan9k/bin/components.lua
A    system/loot/plan9k/bin/cp.lua
A    system/loot/plan9k/bin/dd.lua
A    system/loot/plan9k/bin/df.lua
A    system/loot/plan9k/bin/dmesg.lua
A    system/loot/plan9k/bin/du.lua
A    system/loot/plan9k/bin/echo.lua
A    system/loot/plan9k/bin/edit.lua
A    system/loot/plan9k/bin/find.lua
A    system/loot/plan9k/bin/getty.lua
A    system/loot/plan9k/bin/hostname.lua
A    system/loot/plan9k/bin/init.lua
A    system/loot/plan9k/bin/install.lua
A    system/loot/plan9k/bin/kill.lua
A    system/loot/plan9k/bin/label.lua
A    system/loot/plan9k/bin/ln.lua
A    system/loot/plan9k/bin/ls.lua
A    system/loot/plan9k/bin/lua.lua
A    system/loot/plan9k/bin/mkdir.lua
A    system/loot/plan9k/bin/more.lua
A    system/loot/plan9k/bin/mount.cow.lua
A    system/loot/plan9k/bin/mount.lua
A    system/loot/plan9k/bin/mount.msdos.lua
A    system/loot/plan9k/bin/mv.lua
A    system/loot/plan9k/bin/passwd.lua
A    system/loot/plan9k/bin/pastebin.lua
A    system/loot/plan9k/bin/ps.lua
A    system/loot/plan9k/bin/pwd.lua
A    system/loot/plan9k/bin/rc.lua
A    system/loot/plan9k/bin/readkey.lua
A    system/loot/plan9k/bin/reboot.lua
A    system/loot/plan9k/bin/resolution.lua
A    system/loot/plan9k/bin/rm.lua
A    system/loot/plan9k/bin/sandbox.lua
A    system/loot/plan9k/bin/sh.lua
A    system/loot/plan9k/bin/shutdown.lua
A    system/loot/plan9k/bin/sleep.lua
A    system/loot/plan9k/bin/sshd.lua
A    system/loot/plan9k/bin/tee.lua
A    system/loot/plan9k/bin/touch.lua
A    system/loot/plan9k/bin/uptime.lua
A    system/loot/plan9k/bin/watch.lua
A    system/loot/plan9k/bin/wc.lua
A    system/loot/plan9k/bin/wget.lua
A    system/loot/plan9k/boot
A    system/loot/plan9k/boot/kernel
A    system/loot/plan9k/boot/kernel/pipes
A    system/loot/plan9k/etc
A    system/loot/plan9k/etc/rc.d
A    system/loot/plan9k/etc/rc.d/autoupdate.lua
A    system/loot/plan9k/etc/rc.d/sshd.lua
A    system/loot/plan9k/init.lua
A    system/loot/plan9k/lib
A    system/loot/plan9k/lib/colors.lua
A    system/loot/plan9k/lib/event.lua
A    system/loot/plan9k/lib/internet.lua
A    system/loot/plan9k/lib/modules
A    system/loot/plan9k/lib/modules/base
A    system/loot/plan9k/lib/modules/base/01_gc.lua
A    system/loot/plan9k/lib/modules/base/01_util.lua
A    system/loot/plan9k/lib/modules/base/02_cmd.lua
A    system/loot/plan9k/lib/modules/base/05_vfs.lua
A    system/loot/plan9k/lib/modules/base/06_cowfs.lua
A    system/loot/plan9k/lib/modules/base/09_rootfs.lua
A    system/loot/plan9k/lib/modules/base/10_devfs.lua
A    system/loot/plan9k/lib/modules/base/10_procfs.lua
A    system/loot/plan9k/lib/modules/base/10_sysfs.lua
A    system/loot/plan9k/lib/modules/base/11_block.lua
A    system/loot/plan9k/lib/modules/base/12_mount.lua
A    system/loot/plan9k/lib/modules/base/15_keventd.lua
A    system/loot/plan9k/lib/modules/base/15_userspace.lua
A    system/loot/plan9k/lib/modules/base/16_buffer.lua
A    system/loot/plan9k/lib/modules/base/16_component.lua
A    system/loot/plan9k/lib/modules/base/16_partition.lua
A    system/loot/plan9k/lib/modules/base/16_require.lua
A    system/loot/plan9k/lib/modules/base/17_chatbox.lua
A    system/loot/plan9k/lib/modules/base/17_data.lua
A    system/loot/plan9k/lib/modules/base/17_drive.lua
A    system/loot/plan9k/lib/modules/base/17_eeprom.lua
A    system/loot/plan9k/lib/modules/base/17_gpt.lua
A    system/loot/plan9k/lib/modules/base/17_io.lua
A    system/loot/plan9k/lib/modules/base/17_ipc.lua
A    system/loot/plan9k/lib/modules/base/17_keyboard.lua
A    system/loot/plan9k/lib/modules/base/17_nfc.lua
A    system/loot/plan9k/lib/modules/base/17_tape.lua
A    system/loot/plan9k/lib/modules/base/18_pty.lua
A    system/loot/plan9k/lib/modules/base/18_syscall.lua
A    system/loot/plan9k/lib/modules/base/19_cgroups.lua
A    system/loot/plan9k/lib/modules/base/19_manageg.lua
A    system/loot/plan9k/lib/modules/base/20_threading.lua
A    system/loot/plan9k/lib/modules/base/21_threadUtil.lua
A    system/loot/plan9k/lib/modules/base/21_timer.lua
A    system/loot/plan9k/lib/modules/base/25_init.lua
A    system/loot/plan9k/lib/msdosfs.lua
A    system/loot/plan9k/lib/rc.lua
A    system/loot/plan9k/lib/serialization.lua
A    system/loot/plan9k/lib/shell.lua
A    system/loot/plan9k/lib/sides.lua
A    system/loot/plan9k/lib/term.lua
A    system/loot/plan9k/lib/text.lua
A    system/loot/plan9k/usr
A    system/loot/plan9k/usr/bin
A    system/loot/plan9k/usr/bin/base64.lua
A    system/loot/plan9k/usr/bin/deflate.lua
A    system/loot/plan9k/usr/bin/go.lua
A    system/loot/plan9k/usr/bin/gpg.lua
A    system/loot/plan9k/usr/bin/inflate.lua
A    system/loot/plan9k/usr/bin/md5sum.lua
A    system/loot/plan9k/usr/bin/mkdosfs.lua
A    system/loot/plan9k/usr/bin/mpt.lua
A    system/loot/plan9k/usr/bin/sha256sum.lua
A    system/loot/plan9k/usr/bin/ssh.lua
A    system/loot/plan9k/usr/lib
A    system/loot/plan9k/usr/lib/data.lua
A    system/loot/plan9k/usr/lib/robot.lua
A    system/loot/plan9k/usr/man
A    system/loot/plan9k/usr/man/pipes
A    system/loot/plan9k/usr/sbin
A    system/loot/plan9k/usr/sbin/sshsession.lua
A    system/loot/plan9k/var
A    system/loot/plan9k/var/lib
A    system/loot/plan9k/var/lib/mpt
A    system/loot/plan9k/var/lib/mpt/config.db
A    system/loot/plan9k/var/lib/mpt/mpt.db
Checked out revision 10062.
/usr/bin/fetch https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/machine.lua -o  system/machine.lua
/usr/bin/fetch https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/bios.lua -o  system/bios.lua
/usr/bin/fetch https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/font.hex -o  system/font.hex
g++ ./bin/./main.cpp.o ./bin/./apis/native-lua.cpp.o ./bin/./apis/os.cpp.o ./bin/./apis/system.cpp.o ./bin/./apis/unicode.cpp.o ./bin/./apis/userdata.cpp.o ./bin/./color/color_map.cpp.o ./bin/./components/component.cpp.o ./bin/./components/computer.cpp.o ./bin/./components/data_card.cpp.o ./bin/./components/drive.cpp.o ./bin/./components/eeprom.cpp.o ./bin/./components/filesystem.cpp.o ./bin/./components/gpu.cpp.o ./bin/./components/internet.cpp.o ./bin/./components/keyboard.cpp.o ./bin/./components/modem.cpp.o ./bin/./components/sandbox.cpp.o ./bin/./components/screen.cpp.o ./bin/./drivers/ansi.cpp.o ./bin/./drivers/ansi_escape.cpp.o ./bin/./drivers/basic_term.cpp.o ./bin/./drivers/connection.cpp.o ./bin/./drivers/factory_shell.cpp.o ./bin/./drivers/fs_utils.cpp.o ./bin/./drivers/internet_drv.cpp.o ./bin/./drivers/internet_http.cpp.o ./bin/./drivers/kb_data.cpp.o ./bin/./drivers/kb_drv.cpp.o ./bin/./drivers/modem_drv.cpp.o ./bin/./drivers/mouse_drv.cpp.o ./bin/./drivers/raw_tty.cpp.o ./bin/./drivers/server_pool.cpp.o ./bin/./drivers/term_buffer.cpp.o ./bin/./drivers/worker.cpp.o ./bin/./io/frame.cpp.o ./bin/./model/client.cpp.o ./bin/./model/config.cpp.o ./bin/./model/host.cpp.o ./bin/./model/log.cpp.o ./bin/./model/luaproxy.cpp.o ./bin/./model/prof_log.cpp.o ./bin/./model/value.cpp.o ./bin/./util/crc32.cpp.o ./bin/./util/md5.cpp.o -o ocvm -llua5.2 -lstdc++ -lstdc++fs -pthread -ldl
done
