### PR TITLE
fixed a few GPU issues (palette colors, return values)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ocvm**
 system/**
 /log
 stack.log
+tmp/**

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(lua),)
-	lua=5.2
+	lua=5.3
 endif
 
 TARGET_EXEC ?= ocvm

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ DEPS := $(OBJS:.o=.d)
 
 CPPFLAGS ?= $(INC_FLAGS) -MMD -MP -Wall -g --std=c++17 -O0 -Wl,--no-as-needed
 
-$(TARGET_EXEC): $(OBJS) system/.keep
+$(TARGET_EXEC): $(OBJS) system
 	$(CXX) $(OBJS) -o $@ $(LDFLAGS)
 	@echo done
 
@@ -60,11 +60,14 @@ $(BUILD_DIR)/%.cpp.o: %.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
-system/.keep:
+system:
 	@echo Downloading OpenComputers system files
-	mkdir -p system
-	touch system/.keep
-	command -v svn && svn checkout https://github.com/MightyPirates/OpenComputers/trunk/src/main/resources/assets/opencomputers/loot system/loot || echo "\n\e[36;1mwarning: svn not found. The build will continue, you can manually prepare \`.system/\`\e[m\n"
+
+	git clone -n --depth=1 --filter=tree:0 https://github.com/MightyPirates/OpenComputers/ system/
+	cd system; git sparse-checkout set --no-cone /src/main/resources/assets/opencomputers/loot/; git checkout
+	mv system/src/main/resources/assets/opencomputers/loot/ system/
+	rm -r system/src/
+
 	wget https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/machine.lua -O system/machine.lua
 	wget https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/lua/bios.lua -O system/bios.lua
 	wget https://raw.githubusercontent.com/MightyPirates/OpenComputers/master-MC1.7.10/src/main/resources/assets/opencomputers/font.hex -O system/font.hex
@@ -72,4 +75,4 @@ system/.keep:
 .PHONY: clean
 
 clean:
-	$(RM) -r $(BUILD_DIR) $(TARGET_EXEC) $(TARGET_EXEC)-profiled
+	$(RM) -r $(BUILD_DIR) $(TARGET_EXEC) $(TARGET_EXEC)-profiled system/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(lua),)
-	lua=5.3
+	lua=5.2
 endif
 
 TARGET_EXEC ?= ocvm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(lua),)
-	lua=5.2
+	lua=5.4
 endif
 
 TARGET_EXEC ?= ocvm
@@ -11,8 +11,8 @@ ifneq ($(luapath),)
 	LDFLAGS?=${luapath}/liblua.a
 	INC_FLAGS+=-I${luapath}
 else
-	LDFLAGS?=$(shell pkg-config lua$(lua) --libs 2>/dev/null || pkg-config lua5.3 --libs 2>/dev/null || echo -llua5.2)
-	INC_FLAGS+=$(shell pkg-config lua$(lua) --cflags 2>/dev/null || pkg-config lua5.3 --cflags 2>/dev/null || echo -I/usr/include/lua5.2)
+	LDFLAGS?=$(shell pkg-config lua$(lua) --libs 2>/dev/null || pkg-config lua5.4 --libs 2>/dev/null || pkg-config lua5.3 --libs 2>/dev/null || pkg-config lua5.2 --libs 2>/dev/null)
+	INC_FLAGS+=$(shell pkg-config lua$(lua) --cflags 2>/dev/null || pkg-config lua5.4 --cflags 2>/dev/null || pkg-config lua5.3 --cflags 2>/dev/null || pkg-config lua5.2 --cflags 2>/dev/null)
 endif
 
 ifneq ($(prof),)

--- a/components/gpu.cpp
+++ b/components/gpu.cpp
@@ -386,15 +386,10 @@ int Gpu::setColorContext(lua_State* lua, bool bBack)
   }
 
   auto& ref = bBack ? _bg : _fg;
-
-  // store these here - otherwise we get incorrect return values
-  int orgb = ref.rgb;
-  bool opaletted = ref.paletted;
-
   auto ctx = makeColorContext(ref);
   ref = { rgb, p };
 
-  return ValuePack::ret(lua, orgb, opaletted);
+  return ValuePack::ret(lua, std::get<0>(ctx), std::get<1>(ctx));
 }
 
 int Gpu::getColorAssignment(lua_State* lua, bool bBack)

--- a/components/gpu.cpp
+++ b/components/gpu.cpp
@@ -386,10 +386,15 @@ int Gpu::setColorContext(lua_State* lua, bool bBack)
   }
 
   auto& ref = bBack ? _bg : _fg;
+
+  // store these here - otherwise we get incorrect return values
+  int orgb = ref.rgb;
+  bool opaletted = ref.paletted;
+
   auto ctx = makeColorContext(ref);
   ref = { rgb, p };
 
-  return ValuePack::ret(lua, std::get<0>(ctx), std::get<1>(ctx));
+  return ValuePack::ret(lua, orgb, opaletted);
 }
 
 int Gpu::getColorAssignment(lua_State* lua, bool bBack)

--- a/components/gpu.cpp
+++ b/components/gpu.cpp
@@ -495,7 +495,7 @@ int Gpu::set(int x, int y, const Cell& cell, bool bForce)
           pNext->locked = false;
       }
       if (_screen)
-        _screen->frame()->write(x, y, cell);
+        _screen->frame()->write(x, y, cell, _color_state);
       *pCell = cell;
     }
   }
@@ -592,7 +592,7 @@ void Gpu::invalidate()
   {
     for (int x = 1; x <= _width; x++)
     {
-      _screen->frame()->write(x, y, *get(x, y));
+      _screen->frame()->write(x, y, *get(x, y), _color_state);
     }
   }
 }

--- a/drivers/ansi.cpp
+++ b/drivers/ansi.cpp
@@ -32,17 +32,35 @@ static const unsigned char oc_to_ansi[256] =
 };
 // clang-format on
 
-string to_ansi(unsigned char deflated_rgb, bool foreground)
+string to_ansi_deflated(unsigned char deflated_rgb, bool foreground)
 {
   stringstream ss;
   ss << (foreground ? "3" : "4") << "8;5;" << (int)oc_to_ansi[deflated_rgb];
   return ss.str();
 }
 
-string Ansi::set_color(const Color& fg, const Color& bg)
+string to_ansi_rgb(int rgb, bool foreground)
 {
-  string fg_txt = to_ansi(fg.code, true);
-  string bg_txt = to_ansi(bg.code, false);
+  stringstream ss;
+  ss << (foreground ? "3" : "4") << "8;2;" << (int)((rgb >> 16) & 0xFF)
+    << ";" << (int)((rgb >> 8) & 0xFF) << ";" << (int)(rgb & 0xFF);
+  return ss.str();
+}
+
+string to_ansi(const Color& col, bool foreground, ColorState& cst)
+{
+  if (col.paletted)
+  {
+    return to_ansi_rgb(cst.palette[col.rgb], foreground);
+  } else {
+    return to_ansi_deflated(col.code, foreground);
+  }
+}
+
+string Ansi::set_color(const Color& fg, const Color& bg, ColorState& cst)
+{
+  string fg_txt = to_ansi(fg, true, cst);
+  string bg_txt = to_ansi(bg, false, cst);
 
   return esc + fg_txt + ";" + bg_txt + "m";
 }

--- a/drivers/ansi.h
+++ b/drivers/ansi.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "color/color_types.h"
 #include <string>
 #include <vector>
 using std::string;
@@ -27,6 +28,6 @@ static const string save_pos = esc + "s";
 static const string restore_pos = esc + "u";
 static const string color_reset = esc + "0m";
 
-string set_color(const Color& fg, const Color& bg);
+string set_color(const Color& fg, const Color& bg, ColorState& cst);
 string set_pos(int x, int y);
 };

--- a/drivers/ansi_escape.cpp
+++ b/drivers/ansi_escape.cpp
@@ -119,7 +119,7 @@ string AnsiEscapeTerm::scrub(const string& value) const
   return replace_all(value, "\t", string{ (char)226, (char)144, (char)137, ' ' });
 }
 
-void AnsiEscapeTerm::onWrite(int x, int y, const Cell& cell)
+void AnsiEscapeTerm::onWrite(int x, int y, const Cell& cell, ColorState& cst)
 {
   string cmd = "";
   if (x != _x || y != _y)
@@ -134,7 +134,7 @@ void AnsiEscapeTerm::onWrite(int x, int y, const Cell& cell)
     }
   }
   if (cell.fg.rgb != _fg_rgb || cell.bg.rgb != _bg_rgb)
-    cmd += Ansi::set_color(cell.fg, cell.bg);
+    cmd += Ansi::set_color(cell.fg, cell.bg, cst);
 
   string text = scrub(cell.value);
   cout << cmd << text;

--- a/drivers/ansi_escape.h
+++ b/drivers/ansi_escape.h
@@ -12,7 +12,7 @@ public:
   virtual ~AnsiEscapeTerm();
 
 protected:
-  void onWrite(int x, int y, const Cell& cell) override;
+  void onWrite(int x, int y, const Cell& cell, ColorState& cst) override;
   virtual tuple<int, int> onOpen() override;
   void onUpdate() override;
   void onClose() override;

--- a/drivers/basic_term.cpp
+++ b/drivers/basic_term.cpp
@@ -1,7 +1,7 @@
 #include "basic_term.h"
 #include <iostream>
 
-void BasicTerm::onWrite(int x, int y, const Cell& cell)
+void BasicTerm::onWrite(int x, int y, const Cell& cell, ColorState& cst)
 {
   std::cout << cell.value;
 }

--- a/drivers/basic_term.h
+++ b/drivers/basic_term.h
@@ -5,6 +5,6 @@
 class BasicTerm : public Frame
 {
 protected:
-  void onWrite(int x, int y, const Cell& cell) override;
+  void onWrite(int x, int y, const Cell& cell, ColorState& cst) override;
   tuple<int, int> onOpen() override;
 };

--- a/drivers/fs_utils.h
+++ b/drivers/fs_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>

--- a/io/frame.cpp
+++ b/io/frame.cpp
@@ -1,4 +1,5 @@
 #include "frame.h"
+#include "color/color_types.h"
 
 Frame::~Frame()
 {
@@ -29,11 +30,11 @@ void Frame::close()
   _screen = nullptr;
 }
 
-void Frame::write(int x, int y, const Cell& cell)
+void Frame::write(int x, int y, const Cell& cell, ColorState& _cst)
 {
   if (cell.locked || !on())
     return;
-  onWrite(x, y, cell);
+  onWrite(x, y, cell, _cst);
 }
 
 tuple<int, int> Frame::size() const

--- a/io/frame.h
+++ b/io/frame.h
@@ -37,7 +37,7 @@ class Frame
 protected:
   // REQUIRED PURE VIRTUALS
   // this is called when the emulator wants you to render text in your window
-  virtual void onWrite(int x, int y, const Cell& cell) = 0;
+  virtual void onWrite(int x, int y, const Cell& cell, ColorState& cst) = 0;
 
   // It is required to return the initial size of the window from onOpen
   // If the user later changes the size of the window ...
@@ -94,7 +94,7 @@ public:
   bool update();
 
   // called by the gpu
-  void write(int x, int y, const Cell& cell);
+  void write(int x, int y, const Cell& cell, ColorState& _cst);
   void clear();
 
   // size is updated by calling winched


### PR DESCRIPTION
palette colors are now displayed correctly.  this mostly involved passing around a `ColorState&` object to more places than it was previously passed, and adding a generator for true-color ANSI escapes (`\27[`).

i haven't done really anything with C++ before so some of these changes may be terribly unclean.  however, i can confirm that they do in fact work.

before:
![image](https://user-images.githubusercontent.com/50844998/132381537-5d8ac075-1393-4ea3-83e7-35acb0bd7d0a.png)

after:
![image](https://user-images.githubusercontent.com/50844998/132381675-a6c8b41a-00a3-4723-be3f-22d726c5fa8b.png)
